### PR TITLE
Fix improper time includes, and fix accessing empty std::vectors.

### DIFF
--- a/examples/BasicClient/clientMain.cxx
+++ b/examples/BasicClient/clientMain.cxx
@@ -15,6 +15,10 @@
   #include <limits.h>
   #include <sys/time.h>
   #include <unistd.h>
+#else
+  #include <stdio.h>
+  #include <sys/timeb.h>
+  #include <time.h>
 #endif
 
 #include <boost/cstdint.hpp>
@@ -48,8 +52,8 @@ public:
   {
     TimeStamp retval;
 #ifdef _WIN32
-    timeb currentTime;
-    ::ftime(&currentTime);
+    _timeb currentTime;
+    ::_ftime(&currentTime);
     retval.Seconds = currentTime.time;
     retval.Microseconds = 1000*currentTime.millitm;
 #else

--- a/remus/proto/conversionHelpers.h
+++ b/remus/proto/conversionHelpers.h
@@ -28,7 +28,10 @@ inline void extractVector(BufferType& buffer, std::vector<char>& msg)
     {
     buffer.get();
     }
-  buffer.rdbuf()->sgetn(&msg[0],msg.size());
+  if(msg.size() > 0)
+    {
+    buffer.rdbuf()->sgetn(&msg[0],msg.size());
+    }
 }
 
 //------------------------------------------------------------------------------
@@ -37,7 +40,15 @@ inline std::string extractString(BufferType& buffer, int size)
 {
   std::vector<char> msg(size);
   extractVector(buffer,msg);
-  return std::string(&msg[0],size);
+  if(size > 0)
+    {
+    return std::string(&msg[0],size);
+    }
+  else
+    {
+    return std::string();
+    }
+
 }
 
 


### PR DESCRIPTION
On windows we can't access vectors of length zero, and doing so will throw
runtime errors in debug mode.

Closes #31.
