### PR TITLE
Added sleep helper function.

### DIFF
--- a/remus/testing/Testing.h
+++ b/remus/testing/Testing.h
@@ -50,7 +50,7 @@ namespace testing {
 
 namespace {
 
-static void sleep(int milliseconds)
+static void sleepForMillisec(int milliseconds)
 {
   #ifdef _WIN32
     Sleep(milliseconds);


### PR DESCRIPTION
Fast-fix for #35.  Alternative would be: `boost::this_thread::sleep_for(const chrono::duration<Rep, Period>& rel_time)`, as in

```
void sleep(long millis){
    boost::chrono::duration<long, boost::milli> milliseconds;
    milliseconds toSleep(millis);
    boost::this_thread::sleep_for(&toSleep);
}
```
