### PR TITLE
Move SleepFor function to common as it is pretty common thing to use.

### DIFF
--- a/examples/BasicWorker/CMakeLists.txt
+++ b/examples/BasicWorker/CMakeLists.txt
@@ -6,5 +6,5 @@ set(SRCS_Workers
   )
 
 add_executable(BasicWorker ${SRCS_Workers})
-target_link_libraries(BasicWorker RemusWorker)
+target_link_libraries(BasicWorker RemusWorker RemusCommon)
 Register_Mesh_Worker(BasicWorker "Edges" "Mesh2D")

--- a/examples/BasicWorker/workerMain.cxx
+++ b/examples/BasicWorker/workerMain.cxx
@@ -7,7 +7,7 @@
 =========================================================================*/
 
 #include <remus/worker/Worker.h>
-#include <remus/testing/Testing.h>
+#include <remus/common/SleepFor.h>
 
 #include <vector>
 #include <string>
@@ -43,7 +43,7 @@ int main (int argc, char* argv[])
     {
     if(progress%20==0)
       {
-      remus::testing::sleepForMillisec(1000);
+      remus::common::SleepForMillisec(1000);
 
       jprogress.setValue(progress);
       jprogress.setMessage("Example Message With Random Content");

--- a/examples/InfiniteWorker/CMakeLists.txt
+++ b/examples/InfiniteWorker/CMakeLists.txt
@@ -6,5 +6,5 @@ set(SRCS_Workers
   )
 
 add_executable(InfiniteWorker ${SRCS_Workers})
-target_link_libraries(InfiniteWorker RemusWorker)
+target_link_libraries(InfiniteWorker RemusWorker RemusCommon)
 Register_Mesh_Worker(InfiniteWorker "Edges" "Mesh2D")

--- a/examples/InfiniteWorker/workerMain.cxx
+++ b/examples/InfiniteWorker/workerMain.cxx
@@ -7,11 +7,11 @@
 =========================================================================*/
 
 #include <remus/worker/Worker.h>
+#include <remus/common/SleepFor.h>
+
 #include <vector>
 #include <string>
 #include <iostream>
-
-#include <remus/testing/Testing.h>
 
 int main (int argc, char* argv[])
 {
@@ -53,7 +53,7 @@ int main (int argc, char* argv[])
       {
       if(progress%20==0)
         {
-        remus::testing::sleepForMillisec(1000);
+        remus::common::SleepForMillisec(1000);
         jprogress.setValue(progress);
         jprogress.setMessage("Random Content From InfiniteWorker");
         status.updateProgress(jprogress);

--- a/remus/common/CMakeLists.txt
+++ b/remus/common/CMakeLists.txt
@@ -11,6 +11,7 @@ set(headers
     MeshTypes.h
     remusGlobals.h
     SignalCatcher.h
+    SleepFor.h
     )
 
 #private common files that don't need

--- a/remus/common/SleepFor.h
+++ b/remus/common/SleepFor.h
@@ -1,0 +1,48 @@
+//=============================================================================
+//
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//
+//  Copyright 2012 Sandia Corporation.
+//  Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+//  the U.S. Government retains certain rights in this software.
+//
+//=============================================================================
+#ifndef remus_commmon_SleepFor_h
+#define remus_commmon_SleepFor_h
+
+//for sleeps
+#ifndef _WIN32
+  #include <unistd.h>
+#else
+//For historical reasons, the Windows.h header defaults to including the
+//Winsock.h header file for Windows Sockets 1.1. The declarations in the
+//Winsock.h header file will conflict with the declarations in the Winsock2.h
+//header file required by Windows Sockets 2.0. The WIN32_LEAN_AND_MEAN define
+//prevents the Winsock.h from being included by the Windows.h header.
+# ifndef WIN32_LEAN_AND_MEAN
+#   define WIN32_LEAN_AND_MEAN
+# endif
+  #include <windows.h>
+#endif
+
+namespace remus {
+namespace common {
+
+inline static void SleepForMillisec(int milliseconds)
+{
+  #ifdef _WIN32
+    Sleep(milliseconds);
+  #else
+    usleep(1000*milliseconds);
+  #endif
+}
+
+}
+}
+#endif

--- a/remus/common/testing/CMakeLists.txt
+++ b/remus/common/testing/CMakeLists.txt
@@ -21,6 +21,7 @@ set(testing_execute_process_executable
 remus_unit_test_executable(EXEC_NAME TestExecutable
                            SOURCES ${testing_execute_process_executable}
                           )
+target_link_libraries(TestExecutable LINK_PRIVATE RemusCommon)
 
 #to launch this test executable we need a header that is configured
 #with the correct path

--- a/remus/common/testing/TestExecutable.cxx
+++ b/remus/common/testing/TestExecutable.cxx
@@ -11,7 +11,7 @@
 //=============================================================================
 
 #include <iostream>
-#include <remus/testing/Testing.h> //for sleep
+#include <remus/common/SleepFor.h>
 
 int main(int argc, char** argv)
 {
@@ -33,7 +33,7 @@ int main(int argc, char** argv)
   //determine our behavior
   if(exitNormally == 1)
     {
-    remus::testing::sleepForMillisec(1000);
+    remus::common::SleepForMillisec(1000);
     }
   else if(pollingType == 1)
     {

--- a/remus/common/testing/UnitTestExecuteProcess.cxx
+++ b/remus/common/testing/UnitTestExecuteProcess.cxx
@@ -10,11 +10,13 @@
 //
 //=============================================================================
 
-#include <iostream>
 #include <remus/common/ExecuteProcess.h>
-#include <remus/testing/Testing.h>
 
+#include <remus/common/SleepFor.h>
+#include <remus/testing/Testing.h>
 #include "PathToTestExecutable.h"
+
+#include <iostream>
 
 namespace
 {
@@ -140,7 +142,7 @@ int UnitTestExecuteProcess(int, char *[])
   pollResult = example.poll(1);
   REMUS_ASSERT(pollResult.valid());
 
-  remus::testing::sleepForMillisec(1000);
+  remus::common::SleepForMillisec(1000);
   pollResult = example.poll(0);
   REMUS_ASSERT(pollResult.valid());
 
@@ -164,7 +166,7 @@ int UnitTestExecuteProcess(int, char *[])
   pollResult = example.poll(1);
   REMUS_ASSERT(pollResult.valid());
 
-  remus::testing::sleepForMillisec(1);
+  remus::common::SleepForMillisec(1);
   pollResult = example.poll(0);
   REMUS_ASSERT(pollResult.valid());
 

--- a/remus/server/detail/testing/UnitTestActiveJobs.cxx
+++ b/remus/server/detail/testing/UnitTestActiveJobs.cxx
@@ -9,10 +9,11 @@
 //  PURPOSE.  See the above copyright notice for more information.
 //
 //=============================================================================
-
-
-#include <remus/testing/Testing.h>
 #include <remus/server/detail/ActiveJobs.h>
+
+#include <remus/common/SleepFor.h>
+#include <remus/testing/Testing.h>
+
 
 namespace {
 
@@ -274,7 +275,7 @@ void verify_refresh_jobs()
   for(int i=0; i < 5; ++i)
     { REMUS_ASSERT( (jobs.status(uuids_used[i]).status() == remus::QUEUED) ); }
 
-  remus::testing::sleepForMillisec(100);
+  remus::common::SleepForMillisec(100);
 
   //even after 100 milliseconds we aren't expired
   jobs.markExpiredJobs( monitor );
@@ -283,7 +284,7 @@ void verify_refresh_jobs()
 
   for(int i=0; i < 2; ++i)
     {
-    remus::testing::sleepForMillisec(100);
+    remus::common::SleepForMillisec(100);
     for(int j=0; j < 5; ++j)
       { monitor.refresh(socketIds_used[j]); }
     }
@@ -340,7 +341,7 @@ void verify_expire_jobs()
   //while jobs 0, 1 and 2 will be refreshed and will be valid
   for(int i=0; i < 3; ++i)
     {
-    remus::testing::sleepForMillisec(100);
+    remus::common::SleepForMillisec(100);
     for(int j=0; j < 3; ++j)
       { monitor.refresh(socketIds_used[j]); }
     }

--- a/remus/server/detail/testing/UnitTestSocketMonitor.cxx
+++ b/remus/server/detail/testing/UnitTestSocketMonitor.cxx
@@ -11,8 +11,9 @@
 //=============================================================================
 
 #include <remus/server/detail/SocketMonitor.h>
-#include <remus/proto/zmqSocketIdentity.h>
 
+#include <remus/common/SleepFor.h>
+#include <remus/proto/zmqSocketIdentity.h>
 #include <remus/testing/Testing.h>
 
 #include <boost/lexical_cast.hpp>
@@ -89,6 +90,7 @@ void verify_existence()
 
 void verify_markAsDead()
 {
+  {
   zmq::SocketIdentity sid = make_socketId();
   SocketMonitor monitor;
   monitor.refresh(sid);
@@ -97,6 +99,7 @@ void verify_markAsDead()
   monitor.markAsDead(sid);
   REMUS_ASSERT( (monitor.isDead(sid) == true) );
   REMUS_ASSERT( (monitor.isUnresponsive(sid) == true) );
+  }
 
   //do the same with heartbeating instead of refresh
   {
@@ -203,15 +206,15 @@ void verify_responiveness()
   REMUS_ASSERT( (monitor.isDead(sid) == false) );
   REMUS_ASSERT( (monitor.isUnresponsive(sid) == false) );
 
-  remus::testing::sleepForMillisec(10);
+  remus::common::SleepForMillisec(10);
   REMUS_ASSERT( (monitor.isDead(sid) == false) );
   REMUS_ASSERT( (monitor.isUnresponsive(sid) == false) );
-  remus::testing::sleepForMillisec(25);
+  remus::common::SleepForMillisec(25);
   REMUS_ASSERT( (monitor.isDead(sid) == false) );
   REMUS_ASSERT( (monitor.isUnresponsive(sid) == false) );
 
   //after twice the interval sid's will become unresponsive
-  remus::testing::sleepForMillisec(25);
+  remus::common::SleepForMillisec(25);
   REMUS_ASSERT( (monitor.isDead(sid) == false) );
   REMUS_ASSERT( (monitor.isUnresponsive(sid) == true) );
 

--- a/remus/server/detail/testing/UnitTestWorkerPool.cxx
+++ b/remus/server/detail/testing/UnitTestWorkerPool.cxx
@@ -11,8 +11,10 @@
 //=============================================================================
 #include <remus/server/detail/WorkerPool.h>
 
+#include <remus/common/SleepFor.h>
 #include <remus/proto/zmqSocketIdentity.h>
 #include <remus/server/detail/uuidHelper.h>
+
 #include <remus/testing/Testing.h>
 
 namespace {
@@ -143,7 +145,7 @@ void verify_purge_workers()
   REMUS_ASSERT( (pool.haveWorker(worker1_id, worker_type3D) == true) );
 
   //mark workers as inactive and not ready for jobs by waiting 3 seconds
-  remus::testing::sleepForMillisec(3000);
+  remus::common::SleepForMillisec(3000);
 
   pool.purgeDeadWorkers(monitor);
   REMUS_ASSERT( (pool.haveWaitingWorker(worker_type2D) == false) );

--- a/remus/server/testing/CMakeLists.txt
+++ b/remus/server/testing/CMakeLists.txt
@@ -39,6 +39,7 @@ remus_register_unit_test_worker(EXEC_NAME TestWorker
 #state this executable is required by unit_tests and should be placed
 #in the same location as the unit tests
 remus_unit_test_executable(EXEC_NAME TestWorker SOURCES ${testing_workers})
+target_link_libraries(TestWorker LINK_PRIVATE RemusCommon )
 
 #generate the factory paths header
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/UnitTestWorkerFactoryPaths.h.in

--- a/remus/server/testing/TestWorker.cxx
+++ b/remus/server/testing/TestWorker.cxx
@@ -12,6 +12,7 @@
 
 #include <iostream>
 
+#include <remus/common/SleepFor.h>
 #include <remus/testing/Testing.h>
 
 int main(int argc, char** argv)
@@ -34,7 +35,7 @@ int main(int argc, char** argv)
   //determine our behavior
   if(exitNormally == 1)
     {
-    remus::testing::sleepForMillisec(2000);
+    remus::common::SleepForMillisec(2000);
     }
   else if(pollingType == 1)
     {

--- a/remus/testing/Testing.h
+++ b/remus/testing/Testing.h
@@ -38,34 +38,10 @@
   #pragma GCC diagnostic pop
 #endif
 
-//for sleeps
-#ifndef _WIN32
-  #include <unistd.h>
-#else
-//For historical reasons, the Windows.h header defaults to including the
-//Winsock.h header file for Windows Sockets 1.1. The declarations in the
-//Winsock.h header file will conflict with the declarations in the Winsock2.h
-//header file required by Windows Sockets 2.0. The WIN32_LEAN_AND_MEAN define
-//prevents the Winsock.h from being included by the Windows.h header.
-# ifndef WIN32_LEAN_AND_MEAN
-#   define WIN32_LEAN_AND_MEAN
-# endif
-  #include <windows.h>
-#endif
-
 namespace remus {
 namespace testing {
 
 namespace {
-
-inline static void sleepForMillisec(int milliseconds)
-{
-  #ifdef _WIN32
-    Sleep(milliseconds);
-  #else
-    usleep(1000*milliseconds);
-  #endif
-}
 
 static char* full_character_set()
 {

--- a/remus/worker/detail/testing/UnitTestMessageRouter.cxx
+++ b/remus/worker/detail/testing/UnitTestMessageRouter.cxx
@@ -12,6 +12,7 @@
 
 #include <remus/worker/detail/MessageRouter.h>
 
+#include <remus/common/SleepFor.h>
 #include <remus/proto/Message.h>
 #include <remus/proto/Response.h>
 #include <remus/worker/detail/JobQueue.h>
@@ -94,7 +95,7 @@ void test_job_routing(MessageRouter& mr, zmq::socket_t& socket,
   //gotta wait for all three messages to come in
   while(jq.size()<3){}
 
-  remus::testing::sleepForMillisec(2000);
+  remus::common::SleepForMillisec(2000);
 
   REMUS_ASSERT( (jq.size()>0) );
   REMUS_ASSERT( (jq.size()==3) );

--- a/remus/worker/detail/testing/UnitTestWorkerJobQueue.cxx
+++ b/remus/worker/detail/testing/UnitTestWorkerJobQueue.cxx
@@ -12,6 +12,7 @@
 
 #include <remus/worker/detail/MessageRouter.h>
 
+#include <remus/common/SleepFor.h>
 #include <remus/proto/Message.h>
 #include <remus/proto/Response.h>
 #include <remus/worker/detail/JobQueue.h>
@@ -19,6 +20,8 @@
 #include <remus/proto/zmq.hpp>
 
 #include <remus/testing/Testing.h>
+
+
 
 #include <boost/uuid/uuid.hpp>
 
@@ -82,7 +85,7 @@ void verify_basic_comms(zmq::context_t& context)
   response.send(&jobSocket);
 
   //gotta wait for all three messages to come in
-  remus::testing::sleepForMillisec(2000);
+  remus::common::SleepForMillisec(2000);
 
   while(jq.size()<3){}
   REMUS_ASSERT( (jq.size()>0) );


### PR DESCRIPTION
At the same properly update all the examples to link to remus common, so
that they get the proper includes for the SleepFor functions, as they are
going to move to use boost soon enough.
