### PR TITLE
Getting travis to send cdash update stage component.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - mkdir build
   - cd build
   - cmake -DCMAKE_BUILD_TYPE=$BUILD_CONFIG -DRemus_NO_SYSTEM_BOOST:BOOL=OFF -DRemus_ENABLE_COVERAGE:BOOL=ON ..
-  - ctest -D Experimental -j6 --schedule-random --track Travis
+  - ctest -D ExperimentalUpdate -D Experimental -j6 --schedule-random --track Travis
 
 after_success:
   - cd ..


### PR DESCRIPTION
If we send cdash the update stage component than we are able to query
CDash based on the git SHA1 to see how the build/test did in a programmatic
way. This will result in a way to create CDash badges for Remus.
