### PR TITLE
Updated variable names via find/replace.

### DIFF
--- a/CMake/RemusRegisterWorker.cmake
+++ b/CMake/RemusRegisterWorker.cmake
@@ -9,8 +9,8 @@
 
 #we create a text file that list this mesh worker and its type
 function(Register_Mesh_Worker WorkerExecutableName InputMeshFileType OutputMeshType)
-  message(STATUS "Register_Mesh_Worker called ${EXECUTABLE_OUTPUT_PATH}/${WorkerExecutableName}.rw")
+  message(STATUS "Register_Mesh_Worker called ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${WorkerExecutableName}.rw")
   configure_file(${Remus_SOURCE_DIR}/CMake/RemusWorker.rw.in
-           ${EXECUTABLE_OUTPUT_PATH}/${WorkerExecutableName}.rw
+           ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${WorkerExecutableName}.rw
             @ONLY)
 endfunction()

--- a/CMake/RemusTestingMacros.cmake
+++ b/CMake/RemusTestingMacros.cmake
@@ -89,7 +89,7 @@ function(remus_register_unit_test_worker)
   #set up variables that the config file is looking for
   set(InputMeshFileType ${R_INPUT_TYPE})
   set(OutputMeshType ${R_OUTPUT_TYPE})
-  set(WorkerExecutableName "${EXECUTABLE_OUTPUT_PATH}/${R_EXEC_NAME}")
+  set(WorkerExecutableName "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${R_EXEC_NAME}")
   set(ReqsFileName ${R_EXEC_NAME}.${R_FILE_EXT})
 
   set(R_ABS_FILE_NAME ${R_CONFIG_DIR}/${R_EXEC_NAME}.${R_FILE_EXT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,21 +112,21 @@ endif()
 
 
 ## Set the directory where the binaries will be stored
-set( EXECUTABLE_OUTPUT_PATH
+set( CMAKE_RUNTIME_OUTPUT_DIRECTORY
   ${PROJECT_BINARY_DIR}/bin
   CACHE PATH
   "Directory where all executable will be stored"
 )
 
 ## Set the directory where the libraries will be stored
-set( LIBRARY_OUTPUT_PATH
+set( CMAKE_LIBRARY_OUTPUT_DIRECTORY
   ${PROJECT_BINARY_DIR}/lib
   CACHE PATH
   "Directory where all the libraries will be stored"
 )
 mark_as_advanced(
-  EXECUTABLE_OUTPUT_PATH
-  LIBRARY_OUTPUT_PATH)
+  CMAKE_RUNTIME_OUTPUT_DIRECTORY
+  CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 
 #------------------------------------------------------------------------------
 #--------------------------- Setup Include paths ------------------------------

--- a/examples/TetGen/CMakeLists.txt
+++ b/examples/TetGen/CMakeLists.txt
@@ -15,5 +15,5 @@ add_subdirectory(Worker)
 
 #copy the input testing data to the build directory
 file(COPY data/pmdc.node data/pmdc.poly
-     DESTINATION ${EXECUTABLE_OUTPUT_PATH}
+     DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
      )

--- a/remus/common/testing/PathToTestExecutable.h.in
+++ b/remus/common/testing/PathToTestExecutable.h.in
@@ -20,10 +20,10 @@ struct ExampleApplication
 
   ExampleApplication():
 #ifndef _WIN32
-    name("@EXECUTABLE_OUTPUT_PATH@/TestExecutable")
+    name("@CMAKE_RUNTIME_OUTPUT_DIRECTORY@/TestExecutable")
 #else
-    name("@EXECUTABLE_OUTPUT_PATH@/@CMAKE_CFG_INTDIR@/TestExecutable.exe")
-#endif    
+    name("@CMAKE_RUNTIME_OUTPUT_DIRECTORY@/@CMAKE_CFG_INTDIR@/TestExecutable.exe")
+#endif
   {
   }
 


### PR DESCRIPTION
- Replaced all occurrences of `LIBRARY_OUTPUT_PATH` with `CMAKE_LIBRARY_OUTPUT_DIRECTORY`
- Replaced all occurrences of `EXECUTABLE_OUTPUT_PATH` with `CMAKE_RUNTIME_OUTPUT_DIRECTORY`

Fixes #55.
