### PR TITLE
Actually call valid_test().

### DIFF
--- a/remus/proto/testing/UnitTestJobStatus.cxx
+++ b/remus/proto/testing/UnitTestJobStatus.cxx
@@ -241,7 +241,7 @@ int UnitTestJobStatus(int, char *[])
   mark_test();
   progress_test();
   serialize_test();
-
+  valid_test();
 
   return 0;
 }


### PR DESCRIPTION
Actually calls tests that were written for #75.  Should take care of warning introduced on Travis debug builds.
