### PR TITLE
When the server is deleted we first stop brokering.

### DIFF
--- a/remus/server/Server.cxx
+++ b/remus/server/Server.cxx
@@ -274,7 +274,8 @@ Server::Server(const remus::server::ServerPorts& ports,
 //------------------------------------------------------------------------------
 Server::~Server()
 {
-
+  //when we are destrucing the server, we first need to stop brokering
+  this->stopBrokering();
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This stops segfaults when a server goes out of scope.
