### PR TITLE
Rename libsysTools avoid clobbering the external sysTools package.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ include_directories(
 
 #setup the helper kwsys package, we just need system and process
 #to launch external processes.
-set(KWSYS_NAMESPACE sysTools)
+set(KWSYS_NAMESPACE RemusSysTools)
 set(KWSYS_USE_Process 1)
 set(KWSYS_USE_MD5 1)
 set(KWSYS_INSTALL_LIB_DIR "lib")
@@ -160,12 +160,12 @@ if (BUILD_SHARED_LIBS)
   # On Mac OS X, set the directory included as part of the
   # installed library's path. We only do this to libraries that we plan
   # on installing
-  set_target_properties(sysTools PROPERTIES
+  set_target_properties(RemusSysTools PROPERTIES
                         INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
 
   # When we are building shared we need to mark the static library as having
   # position independent code enabled so it can be embedded into dynamic libraries
-  set_target_properties(sysTools PROPERTIES
+  set_target_properties(RemusSysTools PROPERTIES
                         POSITION_INDEPENDENT_CODE True
                         )
 endif()

--- a/remus/client/CMakeLists.txt
+++ b/remus/client/CMakeLists.txt
@@ -30,7 +30,7 @@ export(PACKAGE RemusClient)
 export(TARGETS RemusClient
                RemusProto
                RemusCommon
-               sysTools
+               RemusSysTools
                FILE RemusClient-exports.cmake)
 
 if(Remus_ENABLE_TESTING)

--- a/remus/common/CMakeLists.txt
+++ b/remus/common/CMakeLists.txt
@@ -31,11 +31,11 @@ set(srcs
 #setup the common library
 add_library(RemusCommon ${srcs} ${headers})
 target_link_libraries(RemusCommon
-                      LINK_PRIVATE sysTools ${Boost_LIBRARIES}
+                      LINK_PRIVATE RemusSysTools ${Boost_LIBRARIES}
                       )
 target_include_directories(RemusCommon
                            PUBLIC  ${Boost_INCLUDE_DIRS}
-                           PRIVATE ${sysTools_BINARY_DIR} )
+                           PRIVATE ${RemusSysTools_BINARY_DIR} )
 
 
 #create the export header symbol exporting
@@ -50,7 +50,7 @@ remus_private_headers(${private_headers})
 
 #setup the exports for the library when used from a build tree
 export(PACKAGE RemusCommon)
-export(TARGETS RemusCommon sysTools FILE RemusCommon-exports.cmake)
+export(TARGETS RemusCommon RemusSysTools FILE RemusCommon-exports.cmake)
 
 if(Remus_ENABLE_TESTING)
   add_subdirectory(testing)

--- a/remus/common/ExecuteProcess.cxx
+++ b/remus/common/ExecuteProcess.cxx
@@ -12,7 +12,7 @@
 
 #include <remus/common/ExecuteProcess.h>
 
-#include <sysTools/Process.h>
+#include <RemusSysTools/Process.h>
 
 namespace{
 
@@ -21,24 +21,24 @@ remus::common::ProcessPipe::PipeType typeToType(int type)
   typedef remus::common::ProcessPipe PPipe;
   typedef remus::common::ProcessPipe::PipeType PipeType;
 
-  sysToolsProcess_Pipes_e processType =
-      static_cast<sysToolsProcess_Pipes_e>(type);
+  RemusSysToolsProcess_Pipes_e processType =
+      static_cast<RemusSysToolsProcess_Pipes_e>(type);
   PipeType pipeType;
   switch(processType)
     {
-    case sysToolsProcess_Pipe_STDIN:
+    case RemusSysToolsProcess_Pipe_STDIN:
       pipeType = PPipe::STDIN;
       break;
-    case sysToolsProcess_Pipe_STDOUT:
+    case RemusSysToolsProcess_Pipe_STDOUT:
       pipeType = PPipe::STDOUT;
       break;
-    case sysToolsProcess_Pipe_STDERR:
+    case RemusSysToolsProcess_Pipe_STDERR:
       pipeType = PPipe::STDERR;
       break;
-    case sysToolsProcess_Pipe_Timeout:
+    case RemusSysToolsProcess_Pipe_Timeout:
       pipeType = PPipe::Timeout;
       break;
-    case sysToolsProcess_Pipe_None:
+    case RemusSysToolsProcess_Pipe_None:
     default:
       pipeType = PPipe::None;
       break;
@@ -54,17 +54,17 @@ namespace common{
 struct ExecuteProcess::Process
 {
 public:
-  sysToolsProcess *Proc;
+  RemusSysToolsProcess *Proc;
   bool Created;
   Process():Created(false)
     {
-    this->Proc = sysToolsProcess_New();
+    this->Proc = RemusSysToolsProcess_New();
     }
   ~Process()
     {
     if(this->Created)
       {
-      sysToolsProcess_Delete(this->Proc);
+      RemusSysToolsProcess_Delete(this->Proc);
       }
 
     }
@@ -106,12 +106,12 @@ void ExecuteProcess::execute(DetachMode mode)
     }
   cmds[size-1]=NULL;
 
-  sysToolsProcess_SetCommand(this->ExternalProcess->Proc, cmds);
-  sysToolsProcess_SetOption(this->ExternalProcess->Proc,
-                            sysToolsProcess_Option_HideWindow, true);
-  sysToolsProcess_SetOption(this->ExternalProcess->Proc,
-                              sysToolsProcess_Option_Detach, (mode==Detached) );
-  sysToolsProcess_Execute(this->ExternalProcess->Proc);
+  RemusSysToolsProcess_SetCommand(this->ExternalProcess->Proc, cmds);
+  RemusSysToolsProcess_SetOption(this->ExternalProcess->Proc,
+                            RemusSysToolsProcess_Option_HideWindow, true);
+  RemusSysToolsProcess_SetOption(this->ExternalProcess->Proc,
+                              RemusSysToolsProcess_Option_Detach, (mode==Detached) );
+  RemusSysToolsProcess_Execute(this->ExternalProcess->Proc);
 
   this->ExternalProcess->Created = true;
 
@@ -123,11 +123,11 @@ void ExecuteProcess::execute(DetachMode mode)
 bool ExecuteProcess::kill()
 {
   if(this->ExternalProcess->Created &&
-     sysToolsProcess_GetState(this->ExternalProcess->Proc) ==
-     sysToolsProcess_State_Executing)
+     RemusSysToolsProcess_GetState(this->ExternalProcess->Proc) ==
+     RemusSysToolsProcess_State_Executing)
     {
-    sysToolsProcess_Kill( this->ExternalProcess->Proc );
-    sysToolsProcess_WaitForExit(this->ExternalProcess->Proc, 0);
+    RemusSysToolsProcess_Kill( this->ExternalProcess->Proc );
+    RemusSysToolsProcess_WaitForExit(this->ExternalProcess->Proc, 0);
     return true;
     }
   return false;
@@ -143,10 +143,10 @@ bool ExecuteProcess::isAlive()
     }
   //poll just to see if the state has changed
   double timeout = -1; //set to a negative number to poll
-  sysToolsProcess_WaitForExit(this->ExternalProcess->Proc, &timeout);
+  RemusSysToolsProcess_WaitForExit(this->ExternalProcess->Proc, &timeout);
 
-  int state = sysToolsProcess_GetState(this->ExternalProcess->Proc);
-  return state == sysToolsProcess_State_Executing;
+  int state = RemusSysToolsProcess_GetState(this->ExternalProcess->Proc);
+  return state == RemusSysToolsProcess_State_Executing;
 }
 
 //-----------------------------------------------------------------------------
@@ -159,10 +159,10 @@ bool ExecuteProcess::exitedNormally()
     }
   //poll just to see if the state has changed
   double timeout = -1; //set to a negative number to poll
-  sysToolsProcess_WaitForExit(this->ExternalProcess->Proc, &timeout);
+  RemusSysToolsProcess_WaitForExit(this->ExternalProcess->Proc, &timeout);
 
-  int state = sysToolsProcess_GetState(this->ExternalProcess->Proc);
-  return (state == sysToolsProcess_State_Exited);
+  int state = RemusSysToolsProcess_GetState(this->ExternalProcess->Proc);
+  return (state == RemusSysToolsProcess_State_Exited);
 }
 
 
@@ -179,19 +179,19 @@ remus::common::ProcessPipe ExecuteProcess::poll(double timeout)
     return PPipe(PPipe::None);
     }
 
-  //convert our syntax for timout to the systools version
+  //convert our syntax for timout to the RemusSysTools version
   //our negative values mean zero for sysToolProcess
   //our zero value means a negative value
   //other wise we are the same
 
-  //systools currently doesn't have a block for inifinte time that acutally works
+  //RemusSysTools currently doesn't have a block for inifinte time that acutally works
   const double fakeInfiniteWait = 100000000;
   double realTimeOut = (timeout == 0 ) ? -1 : ( timeout < 0) ? fakeInfiniteWait : timeout;
 
   //poll sys tool for data
   int length;
   char* data;
-  int pipe = sysToolsProcess_WaitForData(this->ExternalProcess->Proc,
+  int pipe = RemusSysToolsProcess_WaitForData(this->ExternalProcess->Proc,
                                           &data,&length,&realTimeOut);
   PPipe::PipeType type = typeToType(pipe);
 

--- a/remus/common/MD5Hash.cxx
+++ b/remus/common/MD5Hash.cxx
@@ -12,19 +12,19 @@
 
 #include <remus/common/MD5Hash.h>
 
-#include <sysTools/MD5.h>
+#include <RemusSysTools/MD5.h>
 
 namespace
 {
   std::string to_hash(const char* data, const std::size_t length)
   {
-    sysToolsMD5* hasher = sysToolsMD5_New();
-    sysToolsMD5_Initialize(hasher);
-    sysToolsMD5_Append(hasher, reinterpret_cast<const unsigned char*>(data), length);
+    RemusSysToolsMD5* hasher = RemusSysToolsMD5_New();
+    RemusSysToolsMD5_Initialize(hasher);
+    RemusSysToolsMD5_Append(hasher, reinterpret_cast<const unsigned char*>(data), length);
 
     char hash[32];
-    sysToolsMD5_FinalizeHex(hasher, hash);
-    sysToolsMD5_Delete(hasher);
+    RemusSysToolsMD5_FinalizeHex(hasher, hash);
+    RemusSysToolsMD5_Delete(hasher);
     return std::string(hash,32);
   }
 }

--- a/remus/common/testing/CMakeLists.txt
+++ b/remus/common/testing/CMakeLists.txt
@@ -41,4 +41,4 @@ set(unit_tests
   )
 
 remus_unit_tests(SOURCES ${unit_tests}
-                 LIBRARIES sysTools RemusCommon ${Boost_LIBRARIES})
+                 LIBRARIES RemusSysTools RemusCommon ${Boost_LIBRARIES})

--- a/remus/proto/CMakeLists.txt
+++ b/remus/proto/CMakeLists.txt
@@ -56,7 +56,7 @@ remus_private_headers(${private_headers})
 export(PACKAGE RemusProto)
 export(TARGETS RemusProto
                RemusCommon
-               sysTools
+               RemusSysTools
                FILE RemusProto-exports.cmake)
 
 

--- a/remus/server/CMakeLists.txt
+++ b/remus/server/CMakeLists.txt
@@ -41,7 +41,7 @@ remus_public_headers(${headers})
 
 #setup the exports for the library when used from a build tree
 export(PACKAGE RemusServer)
-export(TARGETS RemusServer RemusProto RemusCommon sysTools remuscJSON
+export(TARGETS RemusServer RemusProto RemusCommon RemusSysTools remuscJSON
                FILE Remus-exports.cmake)
 
 if(Remus_ENABLE_TESTING)

--- a/remus/worker/CMakeLists.txt
+++ b/remus/worker/CMakeLists.txt
@@ -35,7 +35,7 @@ remus_public_headers(${headers})
 
 #setup the exports for the library when used from a build tree
 export(PACKAGE RemusWorker)
-export(TARGETS RemusWorker RemusProto RemusCommon sysTools
+export(TARGETS RemusWorker RemusProto RemusCommon RemusSysTools
        FILE RemusWorker-exports.cmake)
 
 if(Remus_ENABLE_TESTING)


### PR DESCRIPTION
Since sysTools the package exists, we need to rename our version of
kwsys to be RemusSysTools to avoid a name collision.
