### PR TITLE
We now find offical release version of ZMQ on windows.

### DIFF
--- a/CMake/FindZeroMQ.cmake
+++ b/CMake/FindZeroMQ.cmake
@@ -1,5 +1,15 @@
+##=============================================================================
+##
+##  Copyright (c) Kitware, Inc.
+##  All rights reserved.
+##  See LICENSE.txt for details.
+##
+##  This software is distributed WITHOUT ANY WARRANTY; without even
+##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+##  PURPOSE.  See the above copyright notice for more information.
+##
+##=============================================================================
 # - Try to find ZeroMQ headers and libraries
-# - THANKS CUBIT FOR THIS FIND MODULE
 #
 # Usage of this module as follows:
 #
@@ -19,31 +29,82 @@
 #  ZeroMQ_INCLUDE_DIR        The location of ZeroMQ headers
 
 find_path(ZeroMQ_ROOT_DIR
-    NAMES include/zmq.h
-)
+  NAMES include/zmq.h
+  )
 
-find_library(ZeroMQ_LIBRARY
+if(MSVC)
+  #add in all the names it can have on windows
+  if(CMAKE_GENERATOR_TOOLSET MATCHES "v140" OR MSVC14)
+    set(_zmq_TOOLSET "-v140")
+  elseif(CMAKE_GENERATOR_TOOLSET MATCHES "v120" OR MSVC12)
+    set(_zmq_TOOLSET "-v120")
+  elseif(CMAKE_GENERATOR_TOOLSET MATCHES "v110_xp")
+    set(_zmq_TOOLSET "-v110_xp")
+  elseif(CMAKE_GENERATOR_TOOLSET MATCHES "v110" OR MSVC11)
+    set(_zmq_TOOLSET "-v110")
+  elseif(CMAKE_GENERATOR_TOOLSET MATCHES "v100" OR MSVC10)
+    set(_zmq_TOOLSET "-v100")
+  elseif(CMAKE_GENERATOR_TOOLSET MATCHES "v90" OR MSVC90)
+    set(_zmq_TOOLSET "-v90")
+  endif()
+
+  set(_zmq_versions "4_0_4" "4_0_3" "4_0_2" "4_0_1" "4_0_0"
+                    "3_2_4" "3_2_3" "3_2_2"  "3_2_1" "3_2_0" "3_1_0")
+  set(_zmq_release_names)
+  set(_zmq_debug_names)
+  foreach( ver ${_zmq_versions})
+    list(APPEND _zmq_release_names "libzmq${_zmq_TOOLSET}-mt-${ver}")
+  endforeach()
+  foreach( ver ${_zmq_versions})
+    list(APPEND _zmq_debug_names "libzmq${_zmq_TOOLSET}-mt-gd-${ver}")
+  endforeach()
+
+  message(STATUS "_zmq_release_names ${_zmq_release_names}")
+  message(STATUS "_zmq_debug_names ${_zmq_debug_names}")
+
+  #now try to find the release and debug version
+  find_library(ZeroMQ_LIBRARY_RELEASE
+    NAMES ${_zmq_release_names} zmq libzmq
+    HINTS ${ZeroMQ_ROOT_DIR}/lib
+          ${ZeroMQ_ROOT_DIR}/bin
+    )
+
+  find_library(ZeroMQ_LIBRARY_DEBUG
+    NAMES ${_zmq_debug_names} zmq libzmq
+    HINTS ${ZeroMQ_ROOT_DIR}/lib
+          ${ZeroMQ_ROOT_DIR}/bin
+    )
+
+  set(ZeroMQ_LIBRARY
+  debug ${ZeroMQ_LIBRARY_DEBUG}
+  optimized ${ZeroMQ_LIBRARY_RELEASE}
+  )
+
+else()
+  find_library(ZeroMQ_LIBRARY
     NAMES zmq libzmq
     HINTS ${ZeroMQ_ROOT_DIR}/lib
-)
+    )
+endif()
 
 find_path(ZeroMQ_INCLUDE_DIR
-    NAMES zmq.h
-    HINTS ${ZeroMQ_ROOT_DIR}/include
-
-)
+  NAMES zmq.h
+  HINTS ${ZeroMQ_ROOT_DIR}/include
+  )
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(ZeroMQ DEFAULT_MSG
-    ZeroMQ_LIBRARY
-    ZeroMQ_INCLUDE_DIR
-)
+  ZeroMQ_LIBRARY
+  ZeroMQ_INCLUDE_DIR
+  )
 
 set(ZeroMQ_INCLUDE_DIRS ${ZeroMQ_INCLUDE_DIR})
 set(ZeroMQ_LIBRARIES ${ZeroMQ_LIBRARY})
 
 mark_as_advanced(
-    ZeroMQ_ROOT_DIR
-    ZeroMQ_LIBRARY
-    ZeroMQ_INCLUDE_DIR
-)
+  ZeroMQ_ROOT_DIR
+  ZeroMQ_LIBRARY
+  ZeroMQ_LIBRARY_DEBUG
+  ZeroMQ_LIBRARY_RELEASE
+  ZeroMQ_INCLUDE_DIR
+  )


### PR DESCRIPTION
ZMQ on windows uses boost library naming style, which we now properly handle.
