### PR TITLE
Remove boost warnings: `-Wunused-parameters`.

### DIFF
--- a/remus/client/ServerConnection.h
+++ b/remus/client/ServerConnection.h
@@ -13,7 +13,14 @@
 #ifndef remus_client_ServerConnection_h
 #define remus_client_ServerConnection_h
 
+#ifndef _MSC_VER
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 #include <remus/proto/zmqSocketInfo.h>
+#ifndef _MSC_VER
+  #pragma GCC diagnostic pop
+#endif
 
 #include <boost/shared_ptr.hpp>
 

--- a/remus/common/PollingMonitor.cxx
+++ b/remus/common/PollingMonitor.cxx
@@ -12,8 +12,15 @@
 
 #include <remus/common/PollingMonitor.h>
 
+#ifndef _MSC_VER
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/circular_buffer.hpp>
+#ifndef _MSC_VER
+  #pragma GCC diagnostic pop
+#endif
 
 #include <algorithm>
 #include <numeric>

--- a/remus/common/testing/UnitTestPollingMonitor.cxx
+++ b/remus/common/testing/UnitTestPollingMonitor.cxx
@@ -10,7 +10,14 @@
 //
 //=============================================================================
 
+#ifndef _MSC_VER
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 #include <boost/date_time/posix_time/posix_time.hpp>
+#ifndef _MSC_VER
+  #pragma GCC diagnostic pop
+#endif
 
 #include <remus/common/PollingMonitor.h>
 

--- a/remus/proto/zmqHelper.h
+++ b/remus/proto/zmqHelper.h
@@ -16,7 +16,14 @@
 #include <algorithm>
 #include <cstddef>
 #include <sstream>
+#ifndef _MSC_VER
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 #include <boost/lexical_cast.hpp>
+#ifndef _MSC_VER
+  #pragma GCC diagnostic pop
+#endif
 
 //We now provide our own zmq.hpp since it has been removed from zmq 3, and
 //made its own project

--- a/remus/proto/zmqSocketInfo.h
+++ b/remus/proto/zmqSocketInfo.h
@@ -13,7 +13,14 @@
 #ifndef remus_proto_zmqSocketInfo_h
 #define remus_proto_zmqSocketInfo_h
 
+#ifndef _MSC_VER
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 #include <boost/lexical_cast.hpp>
+#ifndef _MSC_VER
+  #pragma GCC diagnostic pop
+#endif
 
 #include <remus/proto/zmqTraits.h>
 

--- a/remus/server/Server.cxx
+++ b/remus/server/Server.cxx
@@ -15,6 +15,7 @@
 #ifndef _MSC_VER
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wshadow"
+  #pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
 #include <boost/thread.hpp>
 #ifndef _MSC_VER

--- a/remus/server/detail/SocketMonitor.cxx
+++ b/remus/server/detail/SocketMonitor.cxx
@@ -12,7 +12,14 @@
 
 #include <remus/server/detail/SocketMonitor.h>
 
+#ifndef _MSC_VER
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 #include <boost/date_time/posix_time/posix_time.hpp>
+#ifndef _MSC_VER
+  #pragma GCC diagnostic pop
+#endif
 
 #include <algorithm>
 

--- a/remus/server/detail/uuidHelper.h
+++ b/remus/server/detail/uuidHelper.h
@@ -14,13 +14,14 @@
 #define remus_server_detail_uuidHelper_h
 
 
-#include <boost/uuid/uuid.hpp>
-#include <boost/lexical_cast.hpp>
 //suppress warnings inside boost headers for gcc and clang
 #ifndef _MSC_VER
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wshadow"
+  #pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
+#include <boost/uuid/uuid.hpp>
+#include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #ifndef _MSC_VER
   #pragma GCC diagnostic pop

--- a/remus/testing/Testing.h
+++ b/remus/testing/Testing.h
@@ -24,8 +24,15 @@
 #include <string>
 #include <vector>
 
+#ifndef _MSC_VER
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid.hpp>
+#ifndef _MSC_VER
+  #pragma GCC diagnostic pop
+#endif
 
 //suppress warnings inside boost headers for gcc and clang
 #ifndef _MSC_VER

--- a/remus/worker/detail/JobQueue.cxx
+++ b/remus/worker/detail/JobQueue.cxx
@@ -19,6 +19,7 @@
 #ifndef _MSC_VER
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wshadow"
+  #pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
 #include <boost/thread.hpp>
 #ifndef _MSC_VER

--- a/remus/worker/detail/MessageRouter.cxx
+++ b/remus/worker/detail/MessageRouter.cxx
@@ -19,10 +19,15 @@
 #include <remus/common/PollingMonitor.h>
 #include <remus/worker/Job.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
+#ifndef _MSC_VER
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wshadow"
+#  pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 #include <boost/thread.hpp>
-#pragma GCC diagnostic pop
+#ifndef _MSC_VER
+#  pragma GCC diagnostic pop
+#endif
 
 #include <boost/thread/locks.hpp>
 #include <boost/uuid/uuid.hpp>

--- a/remus/worker/testing/UnitTestWorker.cxx
+++ b/remus/worker/testing/UnitTestWorker.cxx
@@ -18,10 +18,15 @@
 
 #include <boost/scoped_ptr.hpp>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
+#ifndef _MSC_VER
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wshadow"
+#  pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 #include <boost/thread.hpp>
-#pragma GCC diagnostic pop
+#ifndef _MSC_VER
+#  pragma GCC diagnostic pop
+#endif
 
 
 #include <string>


### PR DESCRIPTION
Boost (at least 1.50.0) generates many warnings when compiled
with `-Wunused-parameters`. Eliminate these by disabling the
diagnostic when including boost headers.
