### PR TITLE
Remove sleep from execute process tests since it pauses process on windo...

### DIFF
--- a/remus/common/testing/UnitTestExecuteProcess.cxx
+++ b/remus/common/testing/UnitTestExecuteProcess.cxx
@@ -131,11 +131,6 @@ int UnitTestExecuteProcess(int, char *[])
   REMUS_ASSERT(pollResult.valid());
   REMUS_ASSERT( (pollResult.type == remus::common::ProcessPipe::STDOUT) );
 
-  remus::common::SleepForMillisec(1000);
-  pollResult = example.poll(0);
-  REMUS_ASSERT(pollResult.valid());
-  REMUS_ASSERT( (pollResult.type == remus::common::ProcessPipe::STDOUT) );
-
   //kill the process, and make sure it is terminated
   REMUS_ASSERT(example.kill());
   }
@@ -166,11 +161,6 @@ int UnitTestExecuteProcess(int, char *[])
   REMUS_ASSERT(pollResult.valid());
   REMUS_ASSERT( (pollResult.type == remus::common::ProcessPipe::STDERR) );
 
-  remus::common::SleepForMillisec(1000);
-  pollResult = example.poll(0);
-  REMUS_ASSERT(pollResult.valid());
-  REMUS_ASSERT( (pollResult.type == remus::common::ProcessPipe::STDERR) );
-
   //kill the process, and make sure it is terminated
   REMUS_ASSERT(example.kill());
   }
@@ -178,7 +168,6 @@ int UnitTestExecuteProcess(int, char *[])
 //==============================================================================
 //  Test Polling timeout
 //==============================================================================
-
   {
   //next create a program that will not have output so the polling will
   //timeout
@@ -226,7 +215,6 @@ int UnitTestExecuteProcess(int, char *[])
   //kill the process, and make sure it is terminated
   REMUS_ASSERT(example.kill());
   }
-
 
   return 0;
 }


### PR DESCRIPTION
...ws.

When you call sleep on windows it causes all sub-processes to pause. This causes
a really nasty bug where execute process hangs forever while we are trying to
exit.
