### PR TITLE
Add a test to verify servers waitFor* methods.

### DIFF
--- a/remus/server/testing/CMakeLists.txt
+++ b/remus/server/testing/CMakeLists.txt
@@ -13,6 +13,7 @@
 set(unit_tests
   UnitTestCustomWorkerFactory.cxx
   UnitTestServer.cxx
+  UnitTestServerMonitoring.cxx
   UnitTestWorkerFactory.cxx
   UnitTestServerPorts.cxx
   )
@@ -53,4 +54,5 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/UnitTestWorkerFactoryPaths.h.in
 #calls zmq directly to verify that the binding logic in ServerPorts
 #is correct
 remus_unit_tests(SOURCES ${unit_tests}
-                 LIBRARIES RemusServer RemusProto ${ZeroMQ_LIBRARIES})
+                 LIBRARIES RemusServer RemusProto
+                 ${ZeroMQ_LIBRARIES} ${Boost_LIBRARIES})

--- a/remus/server/testing/UnitTestServerMonitoring.cxx
+++ b/remus/server/testing/UnitTestServerMonitoring.cxx
@@ -1,0 +1,133 @@
+//=============================================================================
+//
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//
+//=============================================================================
+
+#include <remus/server/Server.h>
+#include <remus/server/ServerPorts.h>
+#include <remus/server/WorkerFactory.h>
+#include <remus/testing/Testing.h>
+#include <remus/common/SleepFor.h>
+
+#ifndef _MSC_VER
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wshadow"
+  #pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+
+#include <boost/thread.hpp>
+#include <boost/thread/locks.hpp>
+
+#ifndef _MSC_VER
+  #pragma GCC diagnostic pop
+#endif
+
+namespace {
+
+//------------------------------------------------------------------------------
+remus::server::ServerPorts make_inproc_ports()
+{
+  zmq::socketInfo<zmq::proto::inproc> ci("client_channel");
+  zmq::socketInfo<zmq::proto::inproc> wi("worker_channel");
+  return remus::server::ServerPorts(ci,wi);
+}
+
+//------------------------------------------------------------------------------
+struct ThreadMonitor
+{
+
+  boost::scoped_ptr<boost::thread> Monitor;
+
+  //----------------------------------------------------------------------------
+  ThreadMonitor()
+  {
+  }
+
+  //----------------------------------------------------------------------------
+  ~ThreadMonitor()
+  {
+  this->Monitor->join();
+  }
+
+  //----------------------------------------------------------------------------
+  void join_on_broker_started(remus::server::Server* server)
+  {
+  boost::scoped_ptr<boost::thread> sthread(
+        new  boost::thread(&remus::server::Server::waitForBrokeringToStart, server) );
+  this->Monitor.swap(sthread);
+  }
+
+  //----------------------------------------------------------------------------
+  void join_on_broker_finished(remus::server::Server* server)
+  {
+  boost::scoped_ptr<boost::thread> sthread(
+        new  boost::thread(&remus::server::Server::waitForBrokeringToFinish, server) );
+  std::cout << __LINE__ << std::endl;
+  this->Monitor.swap(sthread);
+  }
+
+  //----------------------------------------------------------------------------
+  bool good()
+  {
+    if(this->Monitor->joinable())
+      {
+      this->Monitor->join();
+      return true;
+      }
+    return false;
+  }
+};
+
+//------------------------------------------------------------------------------
+void test_waitForBrokeringToStart()
+{
+  boost::shared_ptr<remus::Server> server( new remus::Server( make_inproc_ports() ) );
+
+  ThreadMonitor tm;
+  tm.join_on_broker_started(server.get());
+  REMUS_ASSERT( (server->isBrokering() == false) );
+
+  server->startBrokering();
+  REMUS_ASSERT( (server->isBrokering() == true) );
+
+  remus::common::SleepForMillisec(500);
+  REMUS_ASSERT( (tm.good() == true) );
+
+  REMUS_ASSERT( (server->isBrokering() == true) );
+}
+
+//------------------------------------------------------------------------------
+void test_waitForBrokeringToFinish()
+{
+  boost::shared_ptr<remus::Server> server( new remus::Server( make_inproc_ports() ) );
+
+  ThreadMonitor tm;
+  tm.join_on_broker_finished(server.get());
+  REMUS_ASSERT( (server->isBrokering() == false) );
+
+  server->startBrokering();
+  REMUS_ASSERT( (server->isBrokering() == true) );
+
+  remus::common::SleepForMillisec(500);
+  server->stopBrokering();
+
+  REMUS_ASSERT( (tm.good() == true) );
+
+  REMUS_ASSERT( (server->isBrokering() == false) );
+}
+
+} //namespace
+
+int UnitTestServerMonitoring(int, char *[])
+{
+  test_waitForBrokeringToStart();
+  test_waitForBrokeringToFinish();
+  return 0;
+}


### PR DESCRIPTION
Verify that threads monitoring waitForBrokeringToStart() or
waitForBrokeringToFinish() don't hang indefinitely.
