### PR TITLE
Keep working around testing non blocking calls in threaded environment.

### DIFF
--- a/remus/testing/integration/AlwaysAcceptServer.cxx
+++ b/remus/testing/integration/AlwaysAcceptServer.cxx
@@ -215,7 +215,7 @@ void verify_job_status(remus::proto::Job  job,
 {
   using namespace remus::proto;
 
-  remus::common::SleepForMillisec(25);
+  remus::common::SleepForMillisec(250);
   JobStatus currentStatus = client->jobStatus(job);
   const bool valid_status = (currentStatus.status() == statusType);
   REMUS_ASSERT(valid_status)

--- a/remus/testing/integration/SimpleJobFlow.cxx
+++ b/remus/testing/integration/SimpleJobFlow.cxx
@@ -136,8 +136,13 @@ remus::proto::Job verify_job_submission(boost::shared_ptr<remus::Client> client,
   verify_job_status(clientJob,client,remus::QUEUED);
 
   //wait for the server to send the job to the worker
-  remus::common::SleepForMillisec(250);
-  const std::size_t numPendingJobs = worker->pendingJobCount();
+  std::size_t numPendingJobs = worker->pendingJobCount();
+  while(numPendingJobs == 0)
+    {
+    numPendingJobs = worker->pendingJobCount();
+    remus::common::SleepForMillisec(50);
+    numPendingJobs = worker->pendingJobCount();
+    }
   REMUS_ASSERT( (numPendingJobs==1) )
 
   remus::worker::Job workerJob = worker->takePendingJob();


### PR DESCRIPTION
Since we keep testing non blocking methods in a system that has numerous
background threads do work. So we have to wait for the work to be done, but
we don't want to use blocking calls since we are trying to verify the non
blocking versions.
