### PR TITLE
Allow ConditionalStorage to use a pre-allocated boost::shared_array

### DIFF
--- a/remus/common/ConditionalStorage.h
+++ b/remus/common/ConditionalStorage.h
@@ -15,6 +15,7 @@
 
 #include <cstring> //from memcpy
 #include <boost/shared_array.hpp>
+#include <boost/make_shared.hpp>
 #include <vector>
 #include <cstring>
 
@@ -25,16 +26,30 @@ namespace common {
 //coming in has a size greater than zero.
 struct ConditionalStorage
 {
-  ConditionalStorage()
+  //construct an empty storage container
+  ConditionalStorage():
+    Space(),
+    Size(0)
   {
-  this->Size=0;
+  }
+
+  //construct a storage container which holds a reference to the shared_array
+  //that is passed in. This is a way to create a ConditionalStorage that
+  //uses existing allocated memory
+  ConditionalStorage(const boost::shared_array<char>& t,
+                     std::size_t size):
+    Space(t),
+    Size(size)
+  {
   }
 
   //T here needs to be support the .size() and .data() methods
+  //this will copy the contents of T into memory owned by ConditionalStorage
   template<typename T>
-  ConditionalStorage(const T& t)
+  ConditionalStorage(const T& t):
+    Space(),
+    Size(t.size())
   { //copy the contents of t into our storage
-  this->Size = t.size();
   if(this->Size > 0)
     {
     this->Space = boost::shared_array<char>( new char[this->Size] );
@@ -44,9 +59,10 @@ struct ConditionalStorage
 
   //Because of windows 2008. vector does not have .data()
   template<typename T>
-  ConditionalStorage(const std::vector<T>& t)
+  ConditionalStorage(const std::vector<T>& t):
+    Space(),
+    Size(t.size())
   { //copy the contents of t into our storage
-  this->Size = t.size();
   if(this->Size > 0)
     {
     this->Space = boost::shared_array<char>( new char[this->Size] );

--- a/remus/common/testing/UnitTestConditionalStorage.cxx
+++ b/remus/common/testing/UnitTestConditionalStorage.cxx
@@ -85,5 +85,19 @@ int UnitTestConditionalStorage(int, char *[])
   REMUS_ASSERT( ( fhcs.get() != t.get() ) );
 
 
+  //test with an empty boost::shared_array
+  boost::shared_array<char> empty_array;
+  remus::common::ConditionalStorage emptycs(empty_array,0);
+  REMUS_ASSERT( ( emptycs.size() == 0 ) );
+  REMUS_ASSERT( ( emptycs.get() == NULL ) );
+  REMUS_ASSERT( ( emptycs.get() == empty_array.get() ) );
+
+  //test with a boost::shared_array point to 16mb of data
+  boost::shared_array<char> allocated_array( new char[16777216] );
+  remus::common::ConditionalStorage shared_mem_cs(allocated_array,16777216);
+  REMUS_ASSERT( ( shared_mem_cs.size() == 16777216 ) );
+  REMUS_ASSERT( ( shared_mem_cs.get() == allocated_array.get() ) );
+  REMUS_ASSERT( ( shared_mem_cs.get() != empty_array.get() ) );
+
   return 0;
 }


### PR DESCRIPTION
This is a starting place to reduce the amount of memory required to
de-serialize large data inside JobContents.
