### PR TITLE
Add ability to pass env. variables to subprocesses.

### DIFF
--- a/remus/common/ExecuteProcess.h
+++ b/remus/common/ExecuteProcess.h
@@ -13,6 +13,7 @@
 #ifndef remus_common__ExecuteProcess_h
 #define remus_common__ExecuteProcess_h
 
+#include <map>
 #include <set>
 #include <string>
 #include <vector>
@@ -56,6 +57,7 @@ public:
     Attached
   };
 
+  ExecuteProcess(const std::string& command, const std::vector<std::string>& args, const std::map<std::string,std::string>& env);
   ExecuteProcess(const std::string& command, const std::vector<std::string>& args);
   explicit ExecuteProcess(const std::string& command);
 
@@ -93,6 +95,7 @@ private:
 
   std::string Command;
   std::vector<std::string> Args;
+  std::map<std::string,std::string> Env;
 
   struct Process;
   Process* ExternalProcess;

--- a/remus/common/testing/TestExecutable.cxx
+++ b/remus/common/testing/TestExecutable.cxx
@@ -13,8 +13,12 @@
 #include <iostream>
 #include <remus/common/SleepFor.h>
 
+#include <stdlib.h>
+
 int main(int argc, char** argv)
 {
+
+
   //never ending application that needs to be killed
   //and just spews values
   int mode = -1;
@@ -26,7 +30,27 @@ int main(int argc, char** argv)
     else if(prog_type.find("NO_OUTPUT") == 0)
       mode = 1;
     else if( prog_type.find("COUT_OUTPUT") == 0)
+      {
       mode = 2;
+      // If ExecuteProcess did not pass the REMUS_TEST
+      // environment variable, exit early so the test
+      // will fail. This is used to verify that environment
+      // variables can be passed to subprocesses:
+      char* buf;
+      std::string remusTestEnv;
+#if !defined(_WIN32) || defined(__CYGWIN__)
+      buf = getenv("REMUS_TEST");
+      if (buf && buf[0])
+        remusTestEnv = buf;
+#else
+      const bool valid;
+      valid = (_dupenv_s(&buf, NULL, "REMUS_TEST") == 0) && (buf != NULL);
+      if (valid)
+        remusTestEnv = buf;
+#endif
+      if (remusTestEnv != "TRUE")
+        return -1;
+      }
     else if( prog_type.find("CERR_OUTPUT") == 0)
       mode = 3;
     }

--- a/remus/common/testing/UnitTestExecuteProcess.cxx
+++ b/remus/common/testing/UnitTestExecuteProcess.cxx
@@ -79,7 +79,7 @@ int UnitTestExecuteProcess(int, char *[])
   //next create a program that will exit normally, and we won't have to kill
   std::vector< std::string > args;
   args.push_back("SLEEP_AND_EXIT");
-  remus::common::ExecuteProcess example(eapp.name, args );
+  remus::common::ExecuteProcess example(eapp.name, args);
 
   //start the process in non detached-mode
   example.execute(attached);
@@ -112,7 +112,10 @@ int UnitTestExecuteProcess(int, char *[])
   //next step will be to test that we can properly poll an application
   std::vector< std::string > args;
   args.push_back("COUT_OUTPUT");
-  remus::common::ExecuteProcess example(eapp.name, args );
+  //remus::common::ExecuteProcess example(eapp.name, args );
+  std::map< std::string, std::string > env; // test setting environment vars
+  env["REMUS_TEST"] = "TRUE";
+  remus::common::ExecuteProcess example(eapp.name, args, env);
 
   //start the process in attached mode, and test polling
   example.execute(attached);


### PR DESCRIPTION
This adds a new constructor to ExecuteProcess that accepts a `map<string,string>` holding environment variable names and their values. Before the process is spawned, the environment variables are set. Any values that were overwritten are restored in the parent process immediately afterwards (but newly-set values persist).

This is tested by modifying the TestExecutable so that it exits early in COUT_OUTPUT mode if the REMUS_TEST environment variable is not "TRUE".
