### PR TITLE
Fix assertion.

### DIFF
--- a/remus/server/ServerPorts.cxx
+++ b/remus/server/ServerPorts.cxx
@@ -80,7 +80,7 @@ ServerPorts::ServerPorts(const std::string& clientHostName,
   assert(workerHostName.size() > 0);
   assert(workerPort > 0 && workerPort < 65536);
 
-  assert(workerHostName != clientHostName && workerPort != clientPort);
+  assert(!(workerHostName == clientHostName && workerPort == clientPort));
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This would cause crashes in BasicServer (or other servers that set a non-default host that was identical on client and worker listeners).
