### PR TITLE
Default worker factory doesn't support LiveOnFactoryDeletion.

### DIFF
--- a/remus/server/testing/UnitTestWorkerFactory.cxx
+++ b/remus/server/testing/UnitTestWorkerFactory.cxx
@@ -350,13 +350,9 @@ void test_shutdown_with_active_liveOnFactoryDel_workers()
 
   REMUS_ASSERT( (f_def.haveSupport(raw_edges)) );
 
-  //lets try to launch a worker with limit at 1
-  REMUS_ASSERT( (f_def.createWorker(raw_edges,live) == true) );
-
-  //assert only 1 is created
-  REMUS_ASSERT( (f_def.currentWorkerCount() == 1) );
-
-  //now exit with worker still active
+  //lets try to launch a worker with limit at 1. This will fail currently
+  //since the default worker factory doesn't support Live on Factory Deletion
+  REMUS_ASSERT( (f_def.createWorker(raw_edges,live) == false) );
 }
 
 


### PR DESCRIPTION
We are waiting for kwsys execute process to support detaching a child process
after it has been executed. Once that is possible we can re-enable
LiveOnFactoryDeletion.
