### PR TITLE
proto: add export macros to friend decls

### DIFF
--- a/remus/proto/JobResult.h
+++ b/remus/proto/JobResult.h
@@ -88,7 +88,7 @@ public:
     { submission = JobResult(is); return is; }
 
 private:
-  friend remus::proto::JobResult to_JobResult(const char* data, std::size_t size);
+  friend REMUSPROTO_EXPORT remus::proto::JobResult to_JobResult(const char* data, std::size_t size);
   //serialize function
   void serialize(std::ostream& buffer) const;
 

--- a/remus/proto/JobStatus.h
+++ b/remus/proto/JobStatus.h
@@ -121,7 +121,7 @@ public:
     { status = JobStatus(is); return is; }
 
 private:
-  friend remus::proto::JobStatus to_JobStatus(const std::string& msg);
+  friend REMUSPROTO_EXPORT remus::proto::JobStatus to_JobStatus(const std::string& msg);
 
   //serialize function
   void serialize(std::ostream& buffer) const;


### PR DESCRIPTION
VS9 complains that this declaration and the one below are exported
differently.