### PR TITLE
Fixes Issue #232. Job now has a less than operator.

### DIFF
--- a/remus/proto/Job.h
+++ b/remus/proto/Job.h
@@ -41,8 +41,11 @@ public:
   //get the mesh type of the job
   const remus::common::MeshIOType& type() const { return Type; }
 
+  bool operator <(const Job& b) const
+    { return this->Id < b.Id; }
+
   bool operator ==(const Job& b) const
-    { return this->Id == b.Id && this->Type == b.Type; }
+    { return this->Id == b.Id; }
 
   bool operator !=(const Job& b) const
     { return !(this->operator ==(b)); }


### PR DESCRIPTION
We also simplify the comparison operator for Job, as the uuid
is already a unique key, so we have no reason to check the MeshIOType.