### PR TITLE
Update remus to be aware of CMake 3.1, 3.2, and 3.3 policies to specify.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,17 @@ if(POLICY CMP0025)
   cmake_policy(SET CMP0025 NEW)#Clang and AppleClang are different compiler ids
 endif()
 
+#setup policy rules for CMake 3.1 while we have a minimum required of 2.8.X
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0053 NEW)#Enable faster parser engine
+  cmake_policy(SET CMP0054 NEW)#simplify if() argument expansion
+endif()
+
+#setup policy rules for CMake 3.3 while we have a minimum required of 2.8.X
+if(POLICY CMP0063)
+  cmake_policy(SET CMP0063 NEW)#Honor visibility properties for all targets
+endif()
+
 project(Remus)
 
 #------------------------------------------------------------------------------

--- a/thirdparty/cJson/CMakeLists.txt
+++ b/thirdparty/cJson/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(remuscJSON STATIC cJSON.c)
 
 set_target_properties(remuscJSON PROPERTIES
                       POSITION_INDEPENDENT_CODE True
-                      C_VISIBILITY_PRESET     FALSE
+                      C_VISIBILITY_PRESET     hidden
                       )
 
 remus_install_library(remuscJSON)


### PR DESCRIPTION
Also fix a bug in the cJson visibility settings, that was found by
3.3 policy.