### PR TITLE
cmake: remove export(PACKAGE)

### DIFF
--- a/remus/client/CMakeLists.txt
+++ b/remus/client/CMakeLists.txt
@@ -31,7 +31,6 @@ remus_install_library(RemusClient)
 remus_public_headers(${headers} ${protocol_headers})
 
 #setup the exports for the library when used from a build tree
-export(PACKAGE RemusClient)
 export(TARGETS RemusClient
                RemusProto
                RemusCommon

--- a/remus/common/CMakeLists.txt
+++ b/remus/common/CMakeLists.txt
@@ -56,7 +56,6 @@ remus_public_headers(${headers})
 remus_private_headers(${private_headers})
 
 #setup the exports for the library when used from a build tree
-export(PACKAGE RemusCommon)
 export(TARGETS RemusCommon RemusSysTools FILE RemusCommon-exports.cmake)
 
 if(Remus_ENABLE_TESTING)

--- a/remus/proto/CMakeLists.txt
+++ b/remus/proto/CMakeLists.txt
@@ -62,7 +62,6 @@ remus_public_headers(${headers})
 remus_private_headers(${private_headers})
 
 #setup the exports for the library when used from a build tree
-export(PACKAGE RemusProto)
 export(TARGETS RemusProto
                RemusCommon
                RemusSysTools

--- a/remus/server/CMakeLists.txt
+++ b/remus/server/CMakeLists.txt
@@ -52,7 +52,6 @@ remus_install_library(RemusServer)
 remus_public_headers(${headers})
 
 #setup the exports for the library when used from a build tree
-export(PACKAGE RemusServer)
 export(TARGETS RemusServer RemusProto RemusCommon RemusSysTools remuscJSON
                FILE Remus-exports.cmake)
 

--- a/remus/worker/CMakeLists.txt
+++ b/remus/worker/CMakeLists.txt
@@ -56,7 +56,6 @@ remus_install_library(RemusWorker)
 remus_public_headers(${headers})
 
 #setup the exports for the library when used from a build tree
-export(PACKAGE RemusWorker)
 export(TARGETS RemusWorker RemusProto RemusCommon RemusSysTools
        FILE RemusWorker-exports.cmake)
 


### PR DESCRIPTION
The package setup just confuses things when there are multiple Remus
builds happening (e.g., a superbuild, a couple of development trees,
etc.) and which one gets found is based on which one occurred last.
